### PR TITLE
Code changes to add default 'All/Any One' to NetWeaver Workbook Parameters

### DIFF
--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -897,11 +897,13 @@
                         "quote": "'",
                         "delimiter": ",",
                         "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
-                        "value": [],
                         "typeSettings": {
-                          "additionalResourceOptions": [],
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
                           "showDefault": false
                         },
+                        "defaultValue": "value::all",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       },
@@ -915,11 +917,13 @@
                         "quote": "'",
                         "delimiter": ",",
                         "query": "let sidList = dynamic([{AvailabilitySID}]);\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
-                        "value": [],
                         "typeSettings": {
-                          "additionalResourceOptions": [],
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
                           "showDefault": false
                         },
+                        "defaultValue": "value::all",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       }
@@ -1222,11 +1226,13 @@
                         "label": "SID",
                         "type": 2,
                         "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
-                        "value": null,
                         "typeSettings": {
-                          "additionalResourceOptions": [],
+                          "additionalResourceOptions": [
+                            "value::1"
+                          ],
                           "showDefault": false
                         },
+                        "defaultValue": "value::1",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       },
@@ -1240,11 +1246,13 @@
                         "quote": "'",
                         "delimiter": ",",
                         "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where SID_s == '{UtilizationSID}' or '{UtilizationSID}' == ''\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
-                        "value": [],
                         "typeSettings": {
-                          "additionalResourceOptions": [],
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
                           "showDefault": false
                         },
+                        "defaultValue": "value::all",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       },
@@ -1255,10 +1263,13 @@
                         "label": "Work Process Type",
                         "type": 2,
                         "query": "SapNetweaver_ABAPGetWPTable_CL\r\n| distinct Typ_s",
-                        "value": null,
                         "typeSettings": {
-                          "additionalResourceOptions": []
+                          "additionalResourceOptions": [
+                            "value::1"
+                          ],
+                          "showDefault": false
                         },
+                        "defaultValue": "value::1",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       }
@@ -1472,11 +1483,13 @@
                   "label": "SID",
                   "type": 2,
                   "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
-                  "value": null,
                   "typeSettings": {
-                    "additionalResourceOptions": [],
+                    "additionalResourceOptions": [
+                      "value::1"
+                    ],
                     "showDefault": false
                   },
+                  "defaultValue": "value::1",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
                 },
@@ -1491,12 +1504,14 @@
                   "delimiter": ",",
                   "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where SID_s == '{EnqueueStatisticsSID}' or '{EnqueueStatisticsSID}' == ''\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
                   "typeSettings": {
-                    "additionalResourceOptions": [],
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
                     "showDefault": false
                   },
+                  "defaultValue": "value::all",
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces",
-                  "value": []
+                  "resourceType": "microsoft.operationalinsights/workspaces"
                 }
               ],
               "style": "pills",
@@ -2271,11 +2286,13 @@
                   "label": "SID",
                   "type": 2,
                   "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
-                  "value": null,
                   "typeSettings": {
-                    "additionalResourceOptions": [],
+                    "additionalResourceOptions": [
+                      "value::1"
+                    ],
                     "showDefault": false
                   },
+                  "defaultValue": "value::1",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
                 },
@@ -2290,12 +2307,14 @@
                   "delimiter": ",",
                   "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where SID_s == '{QueueStatisticsSID}' or '{QueueStatisticsSID}' == ''\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
                   "typeSettings": {
-                    "additionalResourceOptions": [],
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
                     "showDefault": false
                   },
+                  "defaultValue": "value::all",
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces",
-                  "value": []
+                  "resourceType": "microsoft.operationalinsights/workspaces"
                 }
               ],
               "style": "pills",
@@ -2608,11 +2627,14 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nSapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| distinct Typ_s;",
+                  "query": "let appServerList = dynamic([{QueueStatisticsApplicationServer}]);\r\nSapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({QueueStatisticsTimeRange:start}) .. todatetime({QueueStatisticsTimeRange:end}))\r\n| where SID_s == '{QueueStatisticsSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| distinct Typ_s;",
                   "typeSettings": {
-                    "additionalResourceOptions": [],
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
                     "showDefault": false
                   },
+                  "defaultValue": "value::all",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
                 }


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
Description:
Code changes to add All/Any options to all the parameters used in workbook.
Availability Tab :
![image](https://user-images.githubusercontent.com/74435183/113223129-19082280-924e-11eb-8f74-0da6af24484e.png)
Utilization Tab : 
![image](https://user-images.githubusercontent.com/74435183/113223175-30471000-924e-11eb-940e-960d445d2014.png)
Enqueue Statistics Tab:
![image](https://user-images.githubusercontent.com/74435183/113223209-3f2dc280-924e-11eb-9262-8a08a665b799.png)
Queue Statistics Tab:
![image](https://user-images.githubusercontent.com/74435183/113223235-4ce34800-924e-11eb-8d4b-357049e9d36c.png)



